### PR TITLE
Add pagination and navigation to market listings UI

### DIFF
--- a/src/main/java/co/nytro/market/commands/subcommands/ListingsCommand.java
+++ b/src/main/java/co/nytro/market/commands/subcommands/ListingsCommand.java
@@ -2,6 +2,7 @@ package co.nytro.market.commands.subcommands;
 
 import co.nytro.market.datastores.UIBuilder;
 import co.nytro.market.Market;
+import com.codehusky.huskyui.StateContainer;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -17,8 +18,12 @@ public class ListingsCommand implements CommandExecutor {
     @Override
     public CommandResult execute(CommandSource src, CommandContext args) {
         if (pl.isHuskyUILoaded() && pl.isChestGUIDefault()) {
-            if (args.hasAny("g")) pl.getDataStore().getListingsPagination().sendTo(src);
-            else UIBuilder.getStateContainer(pl.getDataStore().getListings()).launchFor((Player) src);
+            if (args.hasAny("g")) {
+                pl.getDataStore().getListingsPagination().sendTo(src);
+            } else {
+                StateContainer sc = UIBuilder.getStateContainer(pl.getDataStore().getListings());
+                sc.launchFor((Player) src, "Market Page 1");
+            }
         } else {
             pl.getDataStore().getListingsPagination().sendTo(src);
         }


### PR DESCRIPTION
## Summary
- Paginate market listings into 9x6 pages with prev/next arrows
- Launch first market page explicitly in listings command

## Testing
- `gradle build` *(fails: Plugin [id: 'org.spongepowered.plugin', version: '0.8.1'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a892112a9c8326b7c0113fff9fae34