### PR TITLE
Handle empty market listings gracefully

### DIFF
--- a/src/main/java/co/nytro/market/commands/subcommands/ListingsCommand.java
+++ b/src/main/java/co/nytro/market/commands/subcommands/ListingsCommand.java
@@ -3,6 +3,9 @@ package co.nytro.market.commands.subcommands;
 import co.nytro.market.datastores.UIBuilder;
 import co.nytro.market.Market;
 import com.codehusky.huskyui.StateContainer;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import java.util.Optional;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -21,8 +24,12 @@ public class ListingsCommand implements CommandExecutor {
             if (args.hasAny("g")) {
                 pl.getDataStore().getListingsPagination().sendTo(src);
             } else {
-                StateContainer sc = UIBuilder.getStateContainer(pl.getDataStore().getListings());
-                sc.launchFor((Player) src, "Market Page 1");
+                Optional<StateContainer> scOpt = UIBuilder.getStateContainer(pl.getDataStore().getListings());
+                if (scOpt.isPresent()) {
+                    scOpt.get().launchFor((Player) src, "Market Page 1");
+                } else {
+                    src.sendMessage(Text.of(TextColors.RED, "No listings available."));
+                }
             }
         } else {
             pl.getDataStore().getListingsPagination().sendTo(src);

--- a/src/main/java/co/nytro/market/datastores/UIBuilder.java
+++ b/src/main/java/co/nytro/market/datastores/UIBuilder.java
@@ -17,14 +17,19 @@ import org.spongepowered.api.text.format.TextColors;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class UIBuilder {
 
-    public static StateContainer getStateContainer(List<Listing> listings) {
-        StateContainer sc = new StateContainer();
-
+    public static Optional<StateContainer> getStateContainer(List<Listing> listings) {
         final int pageSize = 9 * 5; // Reserve bottom row for controls
         int totalPages = (int) Math.ceil(listings.size() / (double) pageSize);
+
+        if (totalPages == 0) {
+            return Optional.empty();
+        }
+
+        StateContainer sc = new StateContainer();
 
         for (int page = 0; page < totalPages; page++) {
             int start = page * pageSize;
@@ -70,7 +75,7 @@ public class UIBuilder {
             sc.addState(p.build(id));
         }
 
-        return sc;
+        return Optional.of(sc);
     }
 
     private static ActionableElement getElementFromListing(Listing listing, StateContainer sc) {


### PR DESCRIPTION
## Summary
- Return `Optional.empty()` when no listings exist in `UIBuilder`
- Notify players when attempting to open listings UI with no items

## Testing
- `gradle build` *(fails: Plugin [id: 'org.spongepowered.plugin', version: '0.8.1'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a896c464d0832697e63c29b851d485